### PR TITLE
fix(prefab): only use y rotation on movement facing direction

### DIFF
--- a/Runtime/SharedResources/NestedPrefabs/MovementMutator.prefab
+++ b/Runtime/SharedResources/NestedPrefabs/MovementMutator.prefab
@@ -50,6 +50,10 @@ MonoBehaviour:
     yState: 0
     zState: 1
   facingDirection: {fileID: 0}
+  applyFacingDirectionOnAxis:
+    xState: 0
+    yState: 1
+    zState: 0
 --- !u!1 &4314744630004568399
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
The facing direction offset on the movement was previously using
all axes for the rotation facing direction, which meant if the facing
direction object (e.g. headset) was pointing at the ground then the
facing direction would be straight down and this would mean the
target would not move.

A new feature in Zinnia means the facing direction can determine
which axes want to be used for the rotational offset so this is now
used and only the y rotation is used so it works over a simple 2 plane.