### PR TITLE
fix(Prefab): use combined deadzone to prevent double diagonal speed

### DIFF
--- a/Runtime/SharedResources/NestedPrefabs/MovementMutator.prefab
+++ b/Runtime/SharedResources/NestedPrefabs/MovementMutator.prefab
@@ -316,6 +316,41 @@ PrefabInstance:
       propertyPath: timeMultiplier
       value: 3
       objectReference: {fileID: 0}
+    - target: {fileID: 5404456050670069340, guid: 500c4efffcae48341a018274f1293dc9,
+        type: 3}
+      propertyPath: deadzoneCalculation
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5404456050670069340, guid: 500c4efffcae48341a018274f1293dc9,
+        type: 3}
+      propertyPath: lateralDeadzone.minimum
+      value: -0.25
+      objectReference: {fileID: 0}
+    - target: {fileID: 5404456050670069340, guid: 500c4efffcae48341a018274f1293dc9,
+        type: 3}
+      propertyPath: lateralDeadzone.maximum
+      value: 0.25
+      objectReference: {fileID: 0}
+    - target: {fileID: 5404456050670069340, guid: 500c4efffcae48341a018274f1293dc9,
+        type: 3}
+      propertyPath: verticalDeadzone.minimum
+      value: -0.25
+      objectReference: {fileID: 0}
+    - target: {fileID: 5404456050670069340, guid: 500c4efffcae48341a018274f1293dc9,
+        type: 3}
+      propertyPath: verticalDeadzone.maximum
+      value: 0.25
+      objectReference: {fileID: 0}
+    - target: {fileID: 5404456050670069340, guid: 500c4efffcae48341a018274f1293dc9,
+        type: 3}
+      propertyPath: longitudinalDeadzone.minimum
+      value: -0.25
+      objectReference: {fileID: 0}
+    - target: {fileID: 5404456050670069340, guid: 500c4efffcae48341a018274f1293dc9,
+        type: 3}
+      propertyPath: longitudinalDeadzone.maximum
+      value: 0.25
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 500c4efffcae48341a018274f1293dc9, type: 3}
 --- !u!4 &6396025159911319581 stripped

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "dependencies": {
         "io.extendreality.zinnia.unity": "1.20.0",
         "io.extendreality.tilia.utilities.shaders.unity": "1.1.0",
-        "io.extendreality.tilia.input.combinedactions.unity": "1.7.1"
+        "io.extendreality.tilia.input.combinedactions.unity": "1.8.0"
     },
     "files": [
         "*.md",


### PR DESCRIPTION
The CombinedActions AxesToVector3Action now provides a mechanism of
combining the axis values to determine a zonal deadzone and using
this fixes the issue where pushing in a diagonal direction would
cause a doubling of speed.