### PR TITLE
feat(Facade): expose axis multipliers at facade level

### DIFF
--- a/Documentation/API/AxisMoveFacade.md
+++ b/Documentation/API/AxisMoveFacade.md
@@ -14,10 +14,12 @@ The public interface into the Axis Move Prefabs.
   * [Configuration]
   * [ForwardOffset]
   * [HorizontalAxis]
+  * [HorizontalAxisMultiplier]
   * [RotationPivot]
   * [SceneCameras]
   * [Target]
   * [VerticalAxis]
+  * [VerticalAxisMultiplier]
 * [Methods]
   * [ClearForwardOffset()]
   * [ClearHorizontalAxis()]
@@ -27,10 +29,12 @@ The public interface into the Axis Move Prefabs.
   * [ClearVerticalAxis()]
   * [OnAfterForwardOffsetChange()]
   * [OnAfterHorizontalAxisChange()]
+  * [OnAfterHorizontalAxisMultiplierChange()]
   * [OnAfterRotationPivotChange()]
   * [OnAfterSceneCamerasChange()]
   * [OnAfterTargetChange()]
   * [OnAfterVerticalAxisChange()]
+  * [OnAfterVerticalAxisMultiplierChange()]
 
 ## Details
 
@@ -103,6 +107,16 @@ The horizontal axis to control the left/right motion.
 public FloatAction HorizontalAxis { get; set; }
 ```
 
+#### HorizontalAxisMultiplier
+
+Multiply the incoming horizontal axis value to increase/decrease speed of movement.
+
+##### Declaration
+
+```
+public float HorizontalAxisMultiplier { get; set; }
+```
+
 #### RotationPivot
 
 An optional pivot point to rotate the [Target] around.
@@ -141,6 +155,16 @@ The vertical axis to control the forward/backward motion.
 
 ```
 public FloatAction VerticalAxis { get; set; }
+```
+
+#### VerticalAxisMultiplier
+
+Multiply the incoming vertical axis value to increase/decrease speed of movement.
+
+##### Declaration
+
+```
+public float VerticalAxisMultiplier { get; set; }
 ```
 
 ### Methods
@@ -225,6 +249,16 @@ Called after [HorizontalAxis] has been changed.
 protected virtual void OnAfterHorizontalAxisChange()
 ```
 
+#### OnAfterHorizontalAxisMultiplierChange()
+
+Called after [HorizontalAxisMultiplier] has been changed.
+
+##### Declaration
+
+```
+protected virtual void OnAfterHorizontalAxisMultiplierChange()
+```
+
 #### OnAfterRotationPivotChange()
 
 Called after [RotationPivot] has been changed.
@@ -265,6 +299,16 @@ Called after [VerticalAxis] has been changed.
 protected virtual void OnAfterVerticalAxisChange()
 ```
 
+#### OnAfterVerticalAxisMultiplierChange()
+
+Called after [VerticalAxisMultiplier] has been changed.
+
+##### Declaration
+
+```
+protected virtual void OnAfterVerticalAxisMultiplierChange()
+```
+
 [Tilia.Locomotors.AxisMove]: README.md
 [Target]: AxisMoveFacade.md#Target
 [Target]: AxisMoveFacade.md#Target
@@ -280,10 +324,12 @@ protected virtual void OnAfterVerticalAxisChange()
 [VerticalAxis]: AxisMoveFacade.md#VerticalAxis
 [ForwardOffset]: AxisMoveFacade.md#ForwardOffset
 [HorizontalAxis]: AxisMoveFacade.md#HorizontalAxis
+[HorizontalAxisMultiplier]: AxisMoveFacade.md#HorizontalAxisMultiplier
 [RotationPivot]: AxisMoveFacade.md#RotationPivot
 [SceneCameras]: AxisMoveFacade.md#SceneCameras
 [Target]: AxisMoveFacade.md#Target
 [VerticalAxis]: AxisMoveFacade.md#VerticalAxis
+[VerticalAxisMultiplier]: AxisMoveFacade.md#VerticalAxisMultiplier
 [Inheritance]: #Inheritance
 [Namespace]: #Namespace
 [Syntax]: #Syntax
@@ -294,10 +340,12 @@ protected virtual void OnAfterVerticalAxisChange()
 [Configuration]: #Configuration
 [ForwardOffset]: #ForwardOffset
 [HorizontalAxis]: #HorizontalAxis
+[HorizontalAxisMultiplier]: #HorizontalAxisMultiplier
 [RotationPivot]: #RotationPivot
 [SceneCameras]: #SceneCameras
 [Target]: #Target
 [VerticalAxis]: #VerticalAxis
+[VerticalAxisMultiplier]: #VerticalAxisMultiplier
 [Methods]: #Methods
 [ClearForwardOffset()]: #ClearForwardOffset
 [ClearHorizontalAxis()]: #ClearHorizontalAxis
@@ -307,7 +355,9 @@ protected virtual void OnAfterVerticalAxisChange()
 [ClearVerticalAxis()]: #ClearVerticalAxis
 [OnAfterForwardOffsetChange()]: #OnAfterForwardOffsetChange
 [OnAfterHorizontalAxisChange()]: #OnAfterHorizontalAxisChange
+[OnAfterHorizontalAxisMultiplierChange()]: #OnAfterHorizontalAxisMultiplierChange
 [OnAfterRotationPivotChange()]: #OnAfterRotationPivotChange
 [OnAfterSceneCamerasChange()]: #OnAfterSceneCamerasChange
 [OnAfterTargetChange()]: #OnAfterTargetChange
 [OnAfterVerticalAxisChange()]: #OnAfterVerticalAxisChange
+[OnAfterVerticalAxisMultiplierChange()]: #OnAfterVerticalAxisMultiplierChange

--- a/Runtime/Prefabs/Locomotors.AxisMove.Vertical-Slide.Horizontal-Slide.prefab
+++ b/Runtime/Prefabs/Locomotors.AxisMove.Vertical-Slide.Horizontal-Slide.prefab
@@ -46,6 +46,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   horizontalAxis: {fileID: 0}
   verticalAxis: {fileID: 0}
+  horizontalAxisMultiplier: 0.5
+  verticalAxisMultiplier: 0.5
   target: {fileID: 0}
   forwardOffset: {fileID: 0}
   rotationPivot: {fileID: 0}
@@ -54,13 +56,9 @@ MonoBehaviour:
   PositionChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Tilia.Locomotors.AxisMove.AxisMoveFacade+UnityEvent, Tilia.Locomotors.AxisMove.Unity.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   RotationChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Tilia.Locomotors.AxisMove.AxisMoveFacade+UnityEvent, Tilia.Locomotors.AxisMove.Unity.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   configuration: {fileID: 4416863543721941783}
 --- !u!1 &8656648980463976475
 GameObject:
@@ -125,11 +123,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 4193476453515831855}
     m_Modifications:
-    - target: {fileID: 4314744630004568399, guid: cb8d74e8397d7f144abc31f4a5554e4f,
-        type: 3}
-      propertyPath: m_Name
-      value: MovementMutator
-      objectReference: {fileID: 0}
     - target: {fileID: 4314744630004568396, guid: cb8d74e8397d7f144abc31f4a5554e4f,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -184,6 +177,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4314744630004568399, guid: cb8d74e8397d7f144abc31f4a5554e4f,
+        type: 3}
+      propertyPath: m_Name
+      value: MovementMutator
       objectReference: {fileID: 0}
     - target: {fileID: 8562143198972185944, guid: cb8d74e8397d7f144abc31f4a5554e4f,
         type: 3}

--- a/Runtime/Prefabs/Locomotors.AxisMove.Vertical-Slide.Horizontal-SmoothRotate.prefab
+++ b/Runtime/Prefabs/Locomotors.AxisMove.Vertical-Slide.Horizontal-SmoothRotate.prefab
@@ -46,6 +46,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   horizontalAxis: {fileID: 0}
   verticalAxis: {fileID: 0}
+  horizontalAxisMultiplier: 30
+  verticalAxisMultiplier: 1
   target: {fileID: 0}
   forwardOffset: {fileID: 0}
   rotationPivot: {fileID: 0}
@@ -54,13 +56,9 @@ MonoBehaviour:
   PositionChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Tilia.Locomotors.AxisMove.AxisMoveFacade+UnityEvent, Tilia.Locomotors.AxisMove.Unity.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   RotationChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Tilia.Locomotors.AxisMove.AxisMoveFacade+UnityEvent, Tilia.Locomotors.AxisMove.Unity.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   configuration: {fileID: 5325944900120606737}
 --- !u!1 &4422014672373375629
 GameObject:
@@ -126,10 +124,45 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 6277491826606506398}
     m_Modifications:
-    - target: {fileID: 688418527863998161, guid: b334f24fe80d78048be071bd89067f4e,
+    - target: {fileID: 651950426903558978, guid: b334f24fe80d78048be071bd89067f4e,
         type: 3}
-      propertyPath: m_Name
-      value: RotationMutator
+      propertyPath: Modified.m_PersistentCalls.m_Calls.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 651950426903558978, guid: b334f24fe80d78048be071bd89067f4e,
+        type: 3}
+      propertyPath: Modified.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 651950426903558978, guid: b334f24fe80d78048be071bd89067f4e,
+        type: 3}
+      propertyPath: Modified.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 651950426903558978, guid: b334f24fe80d78048be071bd89067f4e,
+        type: 3}
+      propertyPath: Modified.m_PersistentCalls.m_Calls.Array.data[1].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 651950426903558978, guid: b334f24fe80d78048be071bd89067f4e,
+        type: 3}
+      propertyPath: Modified.m_PersistentCalls.m_Calls.Array.data[1].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 651950426903558978, guid: b334f24fe80d78048be071bd89067f4e,
+        type: 3}
+      propertyPath: Modified.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 5325944900120606737}
+    - target: {fileID: 651950426903558978, guid: b334f24fe80d78048be071bd89067f4e,
+        type: 3}
+      propertyPath: Modified.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: NotifyRotationChanged
+      objectReference: {fileID: 0}
+    - target: {fileID: 651950426903558978, guid: b334f24fe80d78048be071bd89067f4e,
+        type: 3}
+      propertyPath: Modified.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
       objectReference: {fileID: 0}
     - target: {fileID: 688418527863998158, guid: b334f24fe80d78048be071bd89067f4e,
         type: 3}
@@ -186,6 +219,11 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 688418527863998161, guid: b334f24fe80d78048be071bd89067f4e,
+        type: 3}
+      propertyPath: m_Name
+      value: RotationMutator
+      objectReference: {fileID: 0}
     - target: {fileID: 4795697142387887123, guid: b334f24fe80d78048be071bd89067f4e,
         type: 3}
       propertyPath: multiplier.y
@@ -195,46 +233,6 @@ PrefabInstance:
         type: 3}
       propertyPath: timeMultiplier
       value: 5
-      objectReference: {fileID: 0}
-    - target: {fileID: 651950426903558978, guid: b334f24fe80d78048be071bd89067f4e,
-        type: 3}
-      propertyPath: Modified.m_PersistentCalls.m_Calls.Array.size
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 651950426903558978, guid: b334f24fe80d78048be071bd89067f4e,
-        type: 3}
-      propertyPath: Modified.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 651950426903558978, guid: b334f24fe80d78048be071bd89067f4e,
-        type: 3}
-      propertyPath: Modified.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 651950426903558978, guid: b334f24fe80d78048be071bd89067f4e,
-        type: 3}
-      propertyPath: Modified.m_PersistentCalls.m_Calls.Array.data[1].m_Mode
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 651950426903558978, guid: b334f24fe80d78048be071bd89067f4e,
-        type: 3}
-      propertyPath: Modified.m_PersistentCalls.m_Calls.Array.data[1].m_CallState
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 651950426903558978, guid: b334f24fe80d78048be071bd89067f4e,
-        type: 3}
-      propertyPath: Modified.m_PersistentCalls.m_Calls.Array.data[0].m_Target
-      value: 
-      objectReference: {fileID: 5325944900120606737}
-    - target: {fileID: 651950426903558978, guid: b334f24fe80d78048be071bd89067f4e,
-        type: 3}
-      propertyPath: Modified.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
-      value: NotifyRotationChanged
-      objectReference: {fileID: 0}
-    - target: {fileID: 651950426903558978, guid: b334f24fe80d78048be071bd89067f4e,
-        type: 3}
-      propertyPath: Modified.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
-      value: UnityEngine.Object, UnityEngine
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: b334f24fe80d78048be071bd89067f4e, type: 3}
@@ -287,11 +285,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 6277491826606506398}
     m_Modifications:
-    - target: {fileID: 4314744630004568399, guid: cb8d74e8397d7f144abc31f4a5554e4f,
-        type: 3}
-      propertyPath: m_Name
-      value: MovementMutator
-      objectReference: {fileID: 0}
     - target: {fileID: 4314744630004568396, guid: cb8d74e8397d7f144abc31f4a5554e4f,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -346,6 +339,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4314744630004568399, guid: cb8d74e8397d7f144abc31f4a5554e4f,
+        type: 3}
+      propertyPath: m_Name
+      value: MovementMutator
       objectReference: {fileID: 0}
     - target: {fileID: 8562143198972185944, guid: cb8d74e8397d7f144abc31f4a5554e4f,
         type: 3}

--- a/Runtime/Prefabs/Locomotors.AxisMove.Vertical-Slide.Horizontal-SnapRotate.prefab
+++ b/Runtime/Prefabs/Locomotors.AxisMove.Vertical-Slide.Horizontal-SnapRotate.prefab
@@ -53,28 +53,18 @@ MonoBehaviour:
   Added:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Visual.CameraColorOverlay+UnityEvent, Zinnia.Runtime, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
   AddTransitioned:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Visual.CameraColorOverlay+UnityEvent, Zinnia.Runtime, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
   Removed:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Visual.CameraColorOverlay+UnityEvent, Zinnia.Runtime, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
   RemoveTransitioned:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Visual.CameraColorOverlay+UnityEvent, Zinnia.Runtime, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
   Changed:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Visual.CameraColorOverlay+UnityEvent, Zinnia.Runtime, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
 --- !u!1 &7230071180439827051
 GameObject:
   m_ObjectHideFlags: 0
@@ -121,6 +111,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   horizontalAxis: {fileID: 0}
   verticalAxis: {fileID: 0}
+  horizontalAxisMultiplier: 45
+  verticalAxisMultiplier: 1
   target: {fileID: 0}
   forwardOffset: {fileID: 0}
   rotationPivot: {fileID: 0}
@@ -129,13 +121,9 @@ MonoBehaviour:
   PositionChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Tilia.Locomotors.AxisMove.AxisMoveFacade+UnityEvent, Tilia.Locomotors.AxisMove.Unity.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   RotationChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Tilia.Locomotors.AxisMove.AxisMoveFacade+UnityEvent, Tilia.Locomotors.AxisMove.Unity.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   configuration: {fileID: 8141976798352271089}
 --- !u!1 &8533430109020295943
 GameObject:
@@ -202,10 +190,35 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 8983542080427643578}
     m_Modifications:
-    - target: {fileID: 688418527863998161, guid: b334f24fe80d78048be071bd89067f4e,
+    - target: {fileID: 651950426903558978, guid: b334f24fe80d78048be071bd89067f4e,
         type: 3}
-      propertyPath: m_Name
-      value: RotationMutator
+      propertyPath: Modified.m_PersistentCalls.m_Calls.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 651950426903558978, guid: b334f24fe80d78048be071bd89067f4e,
+        type: 3}
+      propertyPath: Modified.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 651950426903558978, guid: b334f24fe80d78048be071bd89067f4e,
+        type: 3}
+      propertyPath: Modified.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 651950426903558978, guid: b334f24fe80d78048be071bd89067f4e,
+        type: 3}
+      propertyPath: Modified.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 8141976798352271089}
+    - target: {fileID: 651950426903558978, guid: b334f24fe80d78048be071bd89067f4e,
+        type: 3}
+      propertyPath: Modified.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: NotifyRotationChanged
+      objectReference: {fileID: 0}
+    - target: {fileID: 651950426903558978, guid: b334f24fe80d78048be071bd89067f4e,
+        type: 3}
+      propertyPath: Modified.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
       objectReference: {fileID: 0}
     - target: {fileID: 688418527863998158, guid: b334f24fe80d78048be071bd89067f4e,
         type: 3}
@@ -262,6 +275,11 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 688418527863998161, guid: b334f24fe80d78048be071bd89067f4e,
+        type: 3}
+      propertyPath: m_Name
+      value: RotationMutator
+      objectReference: {fileID: 0}
     - target: {fileID: 4795697142387887123, guid: b334f24fe80d78048be071bd89067f4e,
         type: 3}
       propertyPath: ValueChanged.m_PersistentCalls.m_Calls.Array.size
@@ -301,36 +319,6 @@ PrefabInstance:
         type: 3}
       propertyPath: multiplier.y
       value: 45
-      objectReference: {fileID: 0}
-    - target: {fileID: 651950426903558978, guid: b334f24fe80d78048be071bd89067f4e,
-        type: 3}
-      propertyPath: Modified.m_PersistentCalls.m_Calls.Array.size
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 651950426903558978, guid: b334f24fe80d78048be071bd89067f4e,
-        type: 3}
-      propertyPath: Modified.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 651950426903558978, guid: b334f24fe80d78048be071bd89067f4e,
-        type: 3}
-      propertyPath: Modified.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 651950426903558978, guid: b334f24fe80d78048be071bd89067f4e,
-        type: 3}
-      propertyPath: Modified.m_PersistentCalls.m_Calls.Array.data[0].m_Target
-      value: 
-      objectReference: {fileID: 8141976798352271089}
-    - target: {fileID: 651950426903558978, guid: b334f24fe80d78048be071bd89067f4e,
-        type: 3}
-      propertyPath: Modified.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
-      value: NotifyRotationChanged
-      objectReference: {fileID: 0}
-    - target: {fileID: 651950426903558978, guid: b334f24fe80d78048be071bd89067f4e,
-        type: 3}
-      propertyPath: Modified.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
-      value: UnityEngine.Object, UnityEngine
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: b334f24fe80d78048be071bd89067f4e, type: 3}
@@ -383,11 +371,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 8983542080427643578}
     m_Modifications:
-    - target: {fileID: 4314744630004568399, guid: cb8d74e8397d7f144abc31f4a5554e4f,
-        type: 3}
-      propertyPath: m_Name
-      value: MovementMutator
-      objectReference: {fileID: 0}
     - target: {fileID: 4314744630004568396, guid: cb8d74e8397d7f144abc31f4a5554e4f,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -442,6 +425,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4314744630004568399, guid: cb8d74e8397d7f144abc31f4a5554e4f,
+        type: 3}
+      propertyPath: m_Name
+      value: MovementMutator
       objectReference: {fileID: 0}
     - target: {fileID: 8562143198972185944, guid: cb8d74e8397d7f144abc31f4a5554e4f,
         type: 3}

--- a/Runtime/Prefabs/Locomotors.AxisMove.Vertical-Warp.Horizontal-SnapRotate.prefab
+++ b/Runtime/Prefabs/Locomotors.AxisMove.Vertical-Warp.Horizontal-SnapRotate.prefab
@@ -53,28 +53,18 @@ MonoBehaviour:
   Added:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Visual.CameraColorOverlay+UnityEvent, Zinnia.Runtime, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
   AddTransitioned:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Visual.CameraColorOverlay+UnityEvent, Zinnia.Runtime, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
   Removed:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Visual.CameraColorOverlay+UnityEvent, Zinnia.Runtime, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
   RemoveTransitioned:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Visual.CameraColorOverlay+UnityEvent, Zinnia.Runtime, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
   Changed:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Visual.CameraColorOverlay+UnityEvent, Zinnia.Runtime, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
 --- !u!1 &4854036045483392789
 GameObject:
   m_ObjectHideFlags: 0
@@ -179,6 +169,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   horizontalAxis: {fileID: 0}
   verticalAxis: {fileID: 0}
+  horizontalAxisMultiplier: 45
+  verticalAxisMultiplier: 1
   target: {fileID: 0}
   forwardOffset: {fileID: 0}
   rotationPivot: {fileID: 0}
@@ -187,13 +179,9 @@ MonoBehaviour:
   PositionChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Tilia.Locomotors.AxisMove.AxisMoveFacade+UnityEvent, Tilia.Locomotors.AxisMove.Unity.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   RotationChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Tilia.Locomotors.AxisMove.AxisMoveFacade+UnityEvent, Tilia.Locomotors.AxisMove.Unity.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   configuration: {fileID: 4231809194822756959}
 --- !u!1001 &1593706983094293027
 PrefabInstance:
@@ -202,10 +190,35 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 2843120927645673379}
     m_Modifications:
-    - target: {fileID: 688418527863998161, guid: b334f24fe80d78048be071bd89067f4e,
+    - target: {fileID: 651950426903558978, guid: b334f24fe80d78048be071bd89067f4e,
         type: 3}
-      propertyPath: m_Name
-      value: RotationMutator
+      propertyPath: Modified.m_PersistentCalls.m_Calls.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 651950426903558978, guid: b334f24fe80d78048be071bd89067f4e,
+        type: 3}
+      propertyPath: Modified.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 651950426903558978, guid: b334f24fe80d78048be071bd89067f4e,
+        type: 3}
+      propertyPath: Modified.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 651950426903558978, guid: b334f24fe80d78048be071bd89067f4e,
+        type: 3}
+      propertyPath: Modified.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 4231809194822756959}
+    - target: {fileID: 651950426903558978, guid: b334f24fe80d78048be071bd89067f4e,
+        type: 3}
+      propertyPath: Modified.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: NotifyRotationChanged
+      objectReference: {fileID: 0}
+    - target: {fileID: 651950426903558978, guid: b334f24fe80d78048be071bd89067f4e,
+        type: 3}
+      propertyPath: Modified.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
       objectReference: {fileID: 0}
     - target: {fileID: 688418527863998158, guid: b334f24fe80d78048be071bd89067f4e,
         type: 3}
@@ -262,6 +275,11 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 688418527863998161, guid: b334f24fe80d78048be071bd89067f4e,
+        type: 3}
+      propertyPath: m_Name
+      value: RotationMutator
+      objectReference: {fileID: 0}
     - target: {fileID: 4795697142387887123, guid: b334f24fe80d78048be071bd89067f4e,
         type: 3}
       propertyPath: ValueChanged.m_PersistentCalls.m_Calls.Array.size
@@ -300,36 +318,6 @@ PrefabInstance:
     - target: {fileID: 4795697142387887123, guid: b334f24fe80d78048be071bd89067f4e,
         type: 3}
       propertyPath: ValueChanged.m_PersistentCalls.m_Calls.Array.data[2].m_Arguments.m_ObjectArgumentAssemblyTypeName
-      value: UnityEngine.Object, UnityEngine
-      objectReference: {fileID: 0}
-    - target: {fileID: 651950426903558978, guid: b334f24fe80d78048be071bd89067f4e,
-        type: 3}
-      propertyPath: Modified.m_PersistentCalls.m_Calls.Array.size
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 651950426903558978, guid: b334f24fe80d78048be071bd89067f4e,
-        type: 3}
-      propertyPath: Modified.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 651950426903558978, guid: b334f24fe80d78048be071bd89067f4e,
-        type: 3}
-      propertyPath: Modified.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 651950426903558978, guid: b334f24fe80d78048be071bd89067f4e,
-        type: 3}
-      propertyPath: Modified.m_PersistentCalls.m_Calls.Array.data[0].m_Target
-      value: 
-      objectReference: {fileID: 4231809194822756959}
-    - target: {fileID: 651950426903558978, guid: b334f24fe80d78048be071bd89067f4e,
-        type: 3}
-      propertyPath: Modified.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
-      value: NotifyRotationChanged
-      objectReference: {fileID: 0}
-    - target: {fileID: 651950426903558978, guid: b334f24fe80d78048be071bd89067f4e,
-        type: 3}
-      propertyPath: Modified.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
       value: UnityEngine.Object, UnityEngine
       objectReference: {fileID: 0}
     m_RemovedComponents: []
@@ -383,11 +371,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 2843120927645673379}
     m_Modifications:
-    - target: {fileID: 4314744630004568399, guid: cb8d74e8397d7f144abc31f4a5554e4f,
-        type: 3}
-      propertyPath: m_Name
-      value: MovementMutator
-      objectReference: {fileID: 0}
     - target: {fileID: 4314744630004568396, guid: cb8d74e8397d7f144abc31f4a5554e4f,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -442,6 +425,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4314744630004568399, guid: cb8d74e8397d7f144abc31f4a5554e4f,
+        type: 3}
+      propertyPath: m_Name
+      value: MovementMutator
       objectReference: {fileID: 0}
     - target: {fileID: 8133906945982247102, guid: cb8d74e8397d7f144abc31f4a5554e4f,
         type: 3}

--- a/Runtime/SharedResources/Scripts/AxisMoveConfigurator.cs
+++ b/Runtime/SharedResources/Scripts/AxisMoveConfigurator.cs
@@ -271,16 +271,20 @@
             if (HorizontalToLateral != null)
             {
                 HorizontalToLateral.LateralAxis = Facade.HorizontalAxis;
+                HorizontalToLateral.Multiplier = new Vector3(Facade.HorizontalAxisMultiplier, HorizontalToLateral.Multiplier.y, HorizontalToLateral.Multiplier.z);
                 HorizontalAction = HorizontalToLateral;
+
             }
             else if (HorizontalToVertical != null)
             {
                 HorizontalToVertical.VerticalAxis = Facade.HorizontalAxis;
+                HorizontalToVertical.Multiplier = new Vector3(HorizontalToVertical.Multiplier.x, Facade.HorizontalAxisMultiplier, HorizontalToVertical.Multiplier.z);
                 HorizontalAction = HorizontalToVertical;
             }
             else if (HorizontalToLongitudinal != null)
             {
                 HorizontalToLongitudinal.LongitudinalAxis = Facade.HorizontalAxis;
+                HorizontalToLongitudinal.Multiplier = new Vector3(HorizontalToLongitudinal.Multiplier.x, HorizontalToLongitudinal.Multiplier.y, Facade.HorizontalAxisMultiplier);
                 HorizontalAction = HorizontalToLongitudinal;
             }
         }
@@ -293,16 +297,19 @@
             if (VerticalToLateral != null)
             {
                 VerticalToLateral.LateralAxis = Facade.VerticalAxis;
+                VerticalToLateral.Multiplier = new Vector3(Facade.VerticalAxisMultiplier, VerticalToLateral.Multiplier.y, VerticalToLateral.Multiplier.z);
                 VerticalAction = VerticalToLateral;
             }
             else if (VerticalToVertical != null)
             {
                 VerticalToVertical.VerticalAxis = Facade.VerticalAxis;
+                VerticalToVertical.Multiplier = new Vector3(VerticalToVertical.Multiplier.x, Facade.VerticalAxisMultiplier, VerticalToVertical.Multiplier.z);
                 VerticalAction = VerticalToVertical;
             }
             else if (VerticalToLongitudinal != null)
             {
                 VerticalToLongitudinal.LongitudinalAxis = Facade.VerticalAxis;
+                VerticalToLongitudinal.Multiplier = new Vector3(VerticalToLongitudinal.Multiplier.x, VerticalToLongitudinal.Multiplier.y, Facade.VerticalAxisMultiplier);
                 VerticalAction = VerticalToLongitudinal;
             }
         }

--- a/Runtime/SharedResources/Scripts/AxisMoveFacade.cs
+++ b/Runtime/SharedResources/Scripts/AxisMoveFacade.cs
@@ -63,6 +63,48 @@
                 }
             }
         }
+        [Tooltip("Multiply the incoming horizontal axis value to increase/decrease speed of movement.")]
+        [SerializeField]
+        private float horizontalAxisMultiplier = 1f;
+        /// <summary>
+        /// Multiply the incoming horizontal axis value to increase/decrease speed of movement.
+        /// </summary>
+        public float HorizontalAxisMultiplier
+        {
+            get
+            {
+                return horizontalAxisMultiplier;
+            }
+            set
+            {
+                horizontalAxisMultiplier = value;
+                if (this.IsMemberChangeAllowed())
+                {
+                    OnAfterHorizontalAxisMultiplierChange();
+                }
+            }
+        }
+        [Tooltip("Multiply the incoming vertical axis value to increase/decrease speed of movement.")]
+        [SerializeField]
+        private float verticalAxisMultiplier = 1f;
+        /// <summary>
+        /// Multiply the incoming vertical axis value to increase/decrease speed of movement.
+        /// </summary>
+        public float VerticalAxisMultiplier
+        {
+            get
+            {
+                return verticalAxisMultiplier;
+            }
+            set
+            {
+                verticalAxisMultiplier = value;
+                if (this.IsMemberChangeAllowed())
+                {
+                    OnAfterVerticalAxisMultiplierChange();
+                }
+            }
+        }
         #endregion
 
         #region Target Settings
@@ -277,6 +319,22 @@
         /// Called after <see cref="VerticalAxis"/> has been changed.
         /// </summary>
         protected virtual void OnAfterVerticalAxisChange()
+        {
+            Configuration.ConfigureVerticalAxis();
+        }
+
+        /// <summary>
+        /// Called after <see cref="HorizontalAxisMultiplier"/> has been changed.
+        /// </summary>
+        protected virtual void OnAfterHorizontalAxisMultiplierChange()
+        {
+            Configuration.ConfigureHorizontalAxis();
+        }
+
+        /// <summary>
+        /// Called after <see cref="VerticalAxisMultiplier"/> has been changed.
+        /// </summary>
+        protected virtual void OnAfterVerticalAxisMultiplierChange()
         {
             Configuration.ConfigureVerticalAxis();
         }


### PR DESCRIPTION
The AxisMoveFacade now has a property for Horizontal Axis Multiplier and Vertical Axis Multiplier which will update the relevant internal multiplier vector value on the relevant InputAxis.

This makes it easier to change speed of movement/rotation without needing to drill into the prefab components.

The prefabs have been updated to set their default multiplier values by these settings as well.